### PR TITLE
change GA tracking id

### DIFF
--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -45,7 +45,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
         
-        ga('create', 'UA-10013579-1', 'rockarch.org');
+        ga('create', 'UA-10013579-11', 'rockarch.org');
         ga('send', 'pageview');
 
     </script>


### PR DESCRIPTION
Google Analytics tracking id was part of the rockarch.org property in the analytics. Giving it a new id for osTicket to be its own property.